### PR TITLE
Fix for RefResolutionError on Windows caused by backslashes in schema_dir

### DIFF
--- a/src/kubernetes_validate/utils.py
+++ b/src/kubernetes_validate/utils.py
@@ -71,7 +71,7 @@ def validate(data, desired_version, strict=False):
     finally:
         f.close()
     schema_dir = os.path.dirname(os.path.abspath(schema_file))
-    resolver = jsonschema.RefResolver(base_uri='file://' + schema_dir + '/', referrer=schema)
+    resolver = jsonschema.RefResolver(base_uri='file:///' + schema_dir.replace("\\", "/") + '/', referrer=schema)
 
     try:
         jsonschema.validate(data, schema, resolver=resolver)


### PR DESCRIPTION
On Windows, kubernetes-validate raises a RefResolutionError while trying to resolve the `$ref`'s in schema files. This is caused by back slashes in the `schema_dir` path on Windows. Converting these back slashes to forward slashes resolves the error on Windows. I've also tested the change on macOs.

More about this issue: https://github.com/Julian/jsonschema/issues/98#issuecomment-105475109