### PR TITLE
Add support for validating objects with a to_dict method

### DIFF
--- a/src/kubernetes_validate/utils.py
+++ b/src/kubernetes_validate/utils.py
@@ -6,7 +6,7 @@ import platform
 import re
 import sys
 from distutils.version import LooseVersion
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Generator, List, Union
 
 import jsonschema
 import pkg_resources
@@ -58,7 +58,12 @@ def latest_version() -> str:
     return all_versions()[-1]
 
 
-def validate(data: Dict[str, Any], desired_version: str, strict: bool = False) -> str:
+def validate(data: Union[Dict[str, Any], object], desired_version: str, strict: bool = False) -> str:
+    if not isinstance(data, dict):
+        try:
+            data = data.to_dict()
+        except AttributeError:
+            raise TypeError("data must be a dict or object with a to_dict() method")
     # strip initial v from version (I keep forgetting, so other people will too)
     if desired_version.startswith('v'):
         desired_version = desired_version[1:]

--- a/src/kubernetes_validate/utils.py
+++ b/src/kubernetes_validate/utils.py
@@ -15,8 +15,9 @@ import yaml
 
 from kubernetes_validate.version import __version__
 
+
 class SupportsToDict(Protocol):
-    def to_dict(self) -> dict: ...
+    def to_dict(self) -> dict: ...  # noqa: E704
 
 
 class ValidationError(jsonschema.ValidationError):

--- a/src/kubernetes_validate/utils.py
+++ b/src/kubernetes_validate/utils.py
@@ -7,12 +7,16 @@ import re
 import sys
 from distutils.version import LooseVersion
 from typing import Any, Dict, Generator, List, Union
+from typing_extensions import Protocol
 
 import jsonschema
 import pkg_resources
 import yaml
 
 from kubernetes_validate.version import __version__
+
+class SupportsToDict(Protocol):
+    def to_dict(self) -> dict: ...
 
 
 class ValidationError(jsonschema.ValidationError):
@@ -58,7 +62,7 @@ def latest_version() -> str:
     return all_versions()[-1]
 
 
-def validate(data: Union[Dict[str, Any], Any], desired_version: str, strict: bool = False) -> str:
+def validate(data: Union[Dict[str, Any], SupportsToDict], desired_version: str, strict: bool = False) -> str:
     if not isinstance(data, dict):
         try:
             data = data.to_dict()

--- a/src/kubernetes_validate/utils.py
+++ b/src/kubernetes_validate/utils.py
@@ -58,7 +58,7 @@ def latest_version() -> str:
     return all_versions()[-1]
 
 
-def validate(data: Union[Dict[str, Any], object], desired_version: str, strict: bool = False) -> str:
+def validate(data: Union[Dict[str, Any], Any], desired_version: str, strict: bool = False) -> str:
     if not isinstance(data, dict):
         try:
             data = data.to_dict()

--- a/tests/test_validate_resources.py
+++ b/tests/test_validate_resources.py
@@ -43,3 +43,16 @@ def test_validate_version_too_new():
         assert False
     except utils.VersionNotSupportedError:
         assert True
+
+def test_validate_object_resource():
+    resources = utils.resources_from_file(os.path.join(parent, 'resource.yaml'))
+
+    class ResourceObject(object):
+        def __init__(self, resource):
+            self.resource = resource
+
+        def to_dict(self):
+            return self.resource
+
+    for version in VERSIONS:
+        utils.validate(ResourceObject(resources[0]), version, strict=False)


### PR DESCRIPTION
Thanks for the useful library!

Some other libraries such as [`kubernetes`](https://github.com/kubernetes-client/python), [`kubernetes-asyncio`](https://github.com/tomplus/kubernetes_asyncio), [`kr8s`](https://github.com/kr8s-org/kr8s) and [`lightkube`](https://github.com/gtsystem/lightkube) all have objects that can represent Kubernetes resources, and all of those objects have a `to_dict()` method. This PR adds support for those objects to be passed directly into `kubernetes_validate.validate()`.

```python
import kubernetes_validate
from kr8s.objects import Pod

pod = Pod({
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "name": "my-pod",
        },
        "spec": {
            "containers": [{"name": "pause", "image": "gcr.io/google_containers/pause",}]
        },
    })

kubernetes_validate.validate(pod, "1.28", strict=True)
```